### PR TITLE
Add class colour for shaman

### DIFF
--- a/NLib.lua
+++ b/NLib.lua
@@ -5,6 +5,7 @@ NLib.ClassColors = {
     ["Mage"] = "|cFF3FC6EA",
     ["Warlock"] = "|cFF8787ED",
     ["Paladin"] = "|cFFF48CBA",
+    ["Shaman"] = "|cFF0070DE",
     ["Druid"] = "|cFFFF7C0A",
     ["Priest"] = "|cFFFFFFFF",
     ["Rogue"] = "|cFFFFF468",


### PR DESCRIPTION
This uses the retail dark blue as opposed to the original classic paladin colour for shamans.
Most people in the community are more familiar with the blue colour than the true classic pink.